### PR TITLE
Support storing the Slack exports under the `/logs` folder.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,21 +14,27 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Clean up the repo
-        run: rm -rf .git .github LICENSE README.md
-
       - name: Deploy
         run: |
-          mkdir ~/.ssh && \
-          echo "$SSH_KEY" > ~/.ssh/id_rsa && \
-          echo "$SSH_FINGERPRINT" > ~/.ssh/known_hosts && \
-          chmod 700 -R ~/.ssh && \
-          ssh -i ~/.ssh/id_rsa "$SERVER_SSH" \
-            "cd $SERVER_PATH && find -delete" && \
-          scp -i ~/.ssh/id_rsa -r $(find -maxdepth 1 -mindepth 1) \
-            "$SERVER_SSH":"$SERVER_PATH"
+          # Enable error propagation
+          set -e
+
+          # Setting up the SSH configuration
+          mkdir ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_rsa
+          echo "$SSH_FINGERPRINT" > ~/.ssh/known_hosts
+          chmod 700 -R ~/.ssh
+
+          # Transfer files
+          EXCLUDED_ARGS=()
+          for excludedFile in $EXCLUDED_FILES; do
+            EXCLUDED_ARGS+=("--exclude=${excludedFile}")
+          done
+          rsync --exclude=.git --exclude-from=.gitignore ${EXCLUDED_ARGS[*]} \
+            --delete -cpqr . "$SERVER_SSH":"$SERVER_PATH"
         env:
           SERVER_SSH: user@slack.mod-harbour.org
           SERVER_PATH: slack-logs
           SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
           SSH_FINGERPRINT: slack.mod-harbour.org ${{ secrets.SERVER_SSH_FINGERPRINT }}
+          EXCLUDED_FILES: .gitignore .github LICENSE README.md README.es.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/logs
+/config.json

--- a/.htaccess
+++ b/.htaccess
@@ -8,3 +8,12 @@ DirectoryIndex index.prg
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)$ index.prg/$1 [L]
 </IfModule>
+
+# Disable access to config.json and the logs directory.
+# This is especially important if the logs directory contain corporate exports,
+# which may contain logs from direct messages and private groups.
+
+<Files "config.json">
+    Require all denied
+</Files>
+RedirectMatch 403 ^/logs/.*$

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,41 @@
+# slack-logs
+Una aplicación web para visualizar los logs de un espacio de trabajo de Slack.
+
+Sitio de ejemplo, que usa esta aplicación para mostrar el historial del espacio
+de trabajo de Slack oficial de `mod-harbour`: https://slack.mod-harbour.org
+
+Desarrollado con las tecnologías
+[mod-harbour](https://github.com/FiveTechSoft/mod_harbour) y
+[Mercury MVC](https://github.com/carles9000/mercury).
+
+## Configuración
+
+Esta aplicación toma los datos del historial de un espacio de trabajo de Slack
+a partir de una o más
+[exportaciones de datos estándar](https://slack.com/intl/es/help/articles/201658943-Cómo-exportar-los-datos-de-tu-espacio-de-trabajo)
+del espacio de trabajo. (Las exportaciones corporativas también funcionan, pero
+no pensamos soportar mensajes directos o canales cerrados en el futuro próximo.)
+Cada exportación se debe descomprimir en un directorio
+`logs/<nombre-de-exportación>`, donde `<nombre-de-exportación>` puede ser
+cualquier nombre arbitrario.
+
+Adicionalmente, al configurar la aplicación, se debe crear un fichero
+`config.json` con una clave `exports` que contenga un array que enumere los
+nombres de las exportaciones en orden cronológico:
+
+```json
+{
+    "exports": [
+        "Harbour_Project_Slack_May_20_2019_28_Sep_2019",
+        "Harbour Project Slack_Sep_27_2019_Feb_13_2020",
+        "Harbour_Project_Slack_Feb_13_2020_May_4_2020",
+        "Harbour Project Slack_May_03_2020_Jun_14_2020",
+        "Harbour_Project_Slack_Jun_13_2020_Aug_05_2020"
+    ]
+}
+```
+
+Hay un ejemplo del contenido del directorio `logs` en
+[cristobalnavarro/Slack_ModHarbour](https://github.com/cristobalnavarro/Slack_ModHarbour),
+que contiene las exportaciones del espacio de trabajo de Slack oficial de
+`mod-harbour`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,37 @@
 # slack-logs
 A viewer web application for the logs of a Slack workspace.
 
-Una aplicación web para visualizar los logs de un espacio de trabajo de Slack.
+Example site, using this app to show the history of the official
+`mod-harbour` Slack workspace: https://slack.mod-harbour.org
 
-Example site: https://slack.mod-harbour.org
+Powered by [mod-harbour](https://github.com/FiveTechSoft/mod_harbour) and
+[Mercury MVC](https://github.com/carles9000/mercury).
 
-Powered by [Mercury MVC](https://github.com/carles9000/mercury).
+## Setting up
+
+This app takes its data for the history of a Slack workspace from one or more
+[Standard Exports](https://slack.com/intl/en/help/articles/201658943-Export-your-workspace-data)
+of the workspace. (Corporate Exports will work too, but we're not planning to
+support direct messages or private channels anytime soon.) Each export must be
+unzipped into a `logs/<export-name>` directory, where `<export-name>` can be any
+arbitrary name.
+
+Additionally, when setting up this app, you must create a `config.json` file
+with an `exports` key that contains an array listing the export names in
+chronological order:
+
+```json
+{
+    "exports": [
+        "Harbour_Project_Slack_May_20_2019_28_Sep_2019",
+        "Harbour Project Slack_Sep_27_2019_Feb_13_2020",
+        "Harbour_Project_Slack_Feb_13_2020_May_4_2020",
+        "Harbour Project Slack_May_03_2020_Jun_14_2020",
+        "Harbour_Project_Slack_Jun_13_2020_Aug_05_2020"
+    ]
+}
+```
+
+You may find an example of the contents of the `logs` directory at
+[cristobalnavarro/Slack_ModHarbour](https://github.com/cristobalnavarro/Slack_ModHarbour),
+which contains the exports for the official `mod-harbour` Slack workspace.


### PR DESCRIPTION
This change adds a `.gitignore` file, modifies the readme to include setup information, and adds a Spanish translation of the readme.

Closes #4.